### PR TITLE
switching from bytes.Compare == 0 to bytes.Equal

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func publicKeysEqual(a, b interface{}) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return bytes.Compare(aBytes, bBytes) == 0, nil
+	return bytes.Equal(aBytes, bBytes), nil
 }
 
 func calculateSKID(pubKey crypto.PublicKey) ([]byte, error) {


### PR DESCRIPTION
applying sensible change suggested by `staticcheck`